### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,6 @@
-torch>=2.0.0+cu118
-spikingjelly>=0.0.0.0.15
+torch>=2.0.0
+torchaudio
+torchvision
+spikingjelly
 dcls>=0.1.1
 h5py>=3.11.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 torch>=2.0.0
 torchaudio
 torchvision
-spikingjelly
-dcls>=0.1.1
+spikingjelly @ git+https://github.com/fangwei123456/spikingjelly@master
+dcls @ git+https://github.com/K-H-Ismail/Dilated-Convolution-with-Learnable-Spacings-PyTorch@main
 h5py>=3.11.0


### PR DESCRIPTION
No such 0.0.0.15 version for spikingjelly. Add torchaudio and torchvision dependencies. dcls will bump to 0.1.2 since Dcls2_1d is only available in the github version.